### PR TITLE
do not configure wireguard with SaveConfig

### DIFF
--- a/ansible/roles/vpnpeer/tasks/main.yml
+++ b/ansible/roles/vpnpeer/tasks/main.yml
@@ -6,7 +6,6 @@
     owner: root
     group: root
     mode: 0600
-  changed_when: false
 
 - name: recreate wg interface
   shell: |

--- a/ansible/roles/vpnpeer/templates/wg0.conf.j2
+++ b/ansible/roles/vpnpeer/templates/wg0.conf.j2
@@ -1,7 +1,7 @@
 [Interface]
 PrivateKey = {{ vpn_private_key }}
 ListenPort = {{ vpn_port }}
-SaveConfig = true
+SaveConfig = false
 Address = {{ vpnpeer_address }}/{{ vpnpeer_cidr_suffix }}
 
 {% for peer in groups['validator']|list + groups['public']|list %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-secure-validator",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "main": "src/index.js",
   "repository": "https://github.com/w3f/polkadot-secure-validator",
   "author": "Federico Gimenez <federico@web3.foundation>",


### PR DESCRIPTION
With `SaveConfig` the wireguard configuration changes (after adding new peers for instance) were not properly updated.