### PR TITLE
Clarify initial configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ see [here](https://docs.microsoft.com/en-us/azure/role-based-access-control/role
 for details or [create an issue](https://github.com/w3f/polkadot-secure-validator/issues/new) for
 finer grained access control.
 * GCP: `GOOGLE_APPLICATION_CREDENTIALS` (path to json file with credentials of
-the service account you want to use. This service account needs to have write
-access to compute and network resources. If you have separate projects for your state and your sentry node, this service account needs access to both, see [here](https://cloud.google.com/iam/docs/granting-changing-revoking-access)).
+the service account you want to use; this service account needs to have write
+access to compute and network resources).
 * PACKET: `TF_VAR_auth_token`.
 
 The tool allows you to specify which providers to use, so you don't need to have

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ nodes.
 * `SSH_ID_RSA_VALIDATOR`: path to private SSH key you want to use for the
 validators.
 
-Ansible requires that you add these keys to your ssh-agent, which can be done via `ssh-add`:
+You can easily create them and add them to your ssh-agent as follows:
 
 ```bash
 $ ssh-keygen -f <path>
@@ -71,8 +71,8 @@ $ ssh-add <path>
 $ git clone https://github.com/w3f/secure-validator
 $ cd secure-validator
 $ yarn
-$ cp config/main.sample.json config/main.json
-# now you should customize config/main.json
+$ cp config/main.template.json config/main.json
+# now you should complete and customize config/main.json, using main.sample.json as a reference
 $ yarn sync -c config/main.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ see [here](https://docs.microsoft.com/en-us/azure/role-based-access-control/role
 for details or [create an issue](https://github.com/w3f/polkadot-secure-validator/issues/new) for
 finer grained access control.
 * GCP: `GOOGLE_APPLICATION_CREDENTIALS` (path to json file with credentials of
-the service account you want to use; this service account needs to have write
-access to compute and network resources).
+the service account you want to use. This service account needs to have write
+access to compute and network resources. If you have separate projects for your state and your sentry node, this service account needs access to both, see [here](https://cloud.google.com/iam/docs/granting-changing-revoking-access)).
 * PACKET: `TF_VAR_auth_token`.
 
 The tool allows you to specify which providers to use, so you don't need to have

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ nodes.
 * `SSH_ID_RSA_VALIDATOR`: path to private SSH key you want to use for the
 validators.
 
-You can easily create them and add them to your ssh-agent as follows:
+You can easily create and add them to your ssh-agent as follows:
 
 ```bash
 $ ssh-keygen -f <path>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ nodes.
 * `SSH_ID_RSA_VALIDATOR`: path to private SSH key you want to use for the
 validators.
 
+Ansible requires that you add these keys to your ssh-agent, which can be done via `ssh-add`:
+
+```bash
+$ ssh-keygen -f <path>
+$ ssh-add <path>
+```
+
 ### Syncronization
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ NodeJS, Yarn and Git installed with:
 
 Before using polkadot-secure-validator you need to have installed:
 
-* NodeJS (we recommend to use [nvm](https://github.com/nvm-sh/nvm))
+* NodeJS (we recommend using [nvm](https://github.com/nvm-sh/nvm))
 
 * [Yarn](https://yarnpkg.com/lang/en/docs/install)
 
-* [Terraform](https://www.terraform.io/downloads.html)
+* [Terraform](https://www.terraform.io/downloads.html) (the snap package available via your package manager will not work)
 
-* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) (v2.8+, available through pip)
 
 You will need credentials as environment variables for all the infrastructure providers
 used in the platform creation phase. The tool now supports AWS, Azure, GCP and packet,

--- a/config/main.template.json
+++ b/config/main.template.json
@@ -1,0 +1,62 @@
+{
+  "project": "<whatever-name-you-want>",
+  "polkadotBinary": {
+    "url": "<url-to-most-recent-polkadot-binary>",
+    "checksum": "sha256:<checksum-of-most-recent-polkadot-binary>"
+  },
+  "nodeExporter": {
+    "enabled": true,
+    "binary": {
+      "url": "https://github.com/prometheus/node_exporter/releases/download/v0.18.1/node_exporter-0.18.1.linux-amd64.tar.gz",
+      "checksum": "sha256:b2503fd932f85f4e5baf161268854bf5d22001869b84f00fd2d1f57b51b72424"
+    }
+  },
+  "polkadotNetworkId": "<polkadot-network-id>",
+  "state": {
+    "project": "<gcp-state-project-id>"
+  },
+  "validators": {
+    "telemetryUrl": "<your-telemetry-endpoint>",
+    "loggingFilter": "sync=trace,afg=trace,babe=debug",
+    "nodes": [
+      {
+        "provider": "packet",
+        "machineType": "c1.small.x86",
+        "count": 1,
+        "location": "<packet-server-location>",
+        "projectId": "<your-packet-project-id>",
+        "sshUser": "root"
+      }
+    ]
+  },
+  "publicNodes": {
+    "telemetryUrl": "<your-telemetry-endpoint>",
+    "loggingFilter": "babe=debug",
+    "nodes": [
+      {
+        "provider": "aws",
+        "machineType": "m4.large",
+        "count": 1,
+        "location": "<aws-server-location>",
+        "zone": "<aws-server-zone>",
+        "sshUser": "ubuntu"
+      },
+      {
+        "provider": "azure",
+        "machineType": "Standard_D2s_v3",
+        "count": 1,
+        "location": "<azure-server-location>",
+        "sshUser": "<whatever-azure-ssh-username-you-want>"
+      },      
+      {
+        "provider": "gcp",
+        "machineType": "n1-standard-2",
+        "count": 1,
+        "location": "<gcp-server-location>",
+        "zone": "<gcp-server-zone>",
+        "projectId": "<gcp-project-id>",
+        "sshUser": "<whatever-gcp-ssh-username-you-want>"
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "commander": "^2.20.0",
+    "dotenv": "^8.2.0",
     "fs-extra": "^8.1.0",
     "handlebars": "^4.2.0",
     "node-forge": "^0.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
+const path = require('path');
 const process = require('process');
 const program = require('commander');
+require('dotenv').config({path: path.resolve(process.cwd(), '.env')});
+require('dotenv').config({path: path.resolve(process.cwd(), 'config/.env')});
 
 const clean = require('./lib/actions/clean');
 const sync = require('./lib/actions/sync');


### PR DESCRIPTION
### Summary
Clarifies initial configuration process.

### Why
I wasted some time configuring this tool incorrectly when I first used it (see e.g., #28, #32). I think these changes will help the next user get up and running much quicker.

### How
I mostly tried to clarify instructions. I also added .env support and updated main.sample.json. In total:
- Added dotenv, which will load any .env files in the repos root and config directories.
- Added config/main.template.json, which shows user which variables need to be customized.
- Clarified prerequisite installation instructions in README 
- Updated main.sample.json so it is up to date with current Polkadot release.

### Where You Should Check
The changes in this pull request suggest to the user that the variables state.project variable and publicNodes.nodes.projectId (in main.json) should be the same. This is correct, right? Because ven if we wanted separate projects for our bucket and our instance, we wouldn't be able to access them both because we only have credentials for one GCP service account.