### PR TITLE
Get peer id from system_localPeerId

### DIFF
--- a/ansible/roles/polkadot-common/tasks/main.yml
+++ b/ansible/roles/polkadot-common/tasks/main.yml
@@ -67,21 +67,21 @@
   changed_when: false
   when: polkadot_service_running.stdout == "no"
 
-- name: save networkState
+- name: save peerId
   uri:
     url: http://localhost:9933
     method: "POST"
     body_format: json
     body: |
-      { "jsonrpc":"2.0", "method":"system_networkState", "params":[], "id":1 }
-  register: network_state
-  until: network_state.status == 200
+      { "jsonrpc":"2.0", "method":"system_localPeerId", "params":[], "id":1 }
+  register: peerId
+  until: peerId.status == 200
   retries: 5
   delay: 5
 
 - name: set peer id as fact
   set_fact:
-    p2p_peer_id: "{{ network_state.json.result.peerId }}"
+    p2p_peer_id: "{{ peerId.json.result }}"
 
 - name: stop polkadot dummy service
   systemd:


### PR DESCRIPTION
Replaced system.networkState rpc call with system_localPeerId, it seems to be a bit more reliable.