### PR TITLE
Allow zero size blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-secure-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.js",
   "repository": "https://github.com/w3f/polkadot-secure-validator",
   "author": "W3F Infrastructure Team <devops@web3.foundation>",

--- a/src/lib/clients/terraform.js
+++ b/src/lib/clients/terraform.js
@@ -138,7 +138,7 @@ class Terraform {
       location: node.location,
       zone: node.zone,
       projectId: node.projectId,
-      nodeCount: node.count || 1,
+      nodeCount: node.count,
       name: nodeName
     }
 


### PR DESCRIPTION
Towards https://github.com/w3f/infrastructure/issues/155

This change allows us to keep the same indexes on validators/public nodes after having removed a whole block so that the subsequent blocks are not recreated.