### PR TITLE
Support paths with spaces in Ansible inventory path.

### DIFF
--- a/src/lib/clients/ansible.js
+++ b/src/lib/clients/ansible.js
@@ -22,7 +22,7 @@ class Ansible {
   async sync() {
     const inventoryPath = this._writeInventory();
     //return this._cmd(`all -b -m ping -i ${inventoryFileName}`, this.options);
-    return this._cmd(`main.yml -f 30 -i ${inventoryPath}`);
+    return this._cmd(`main.yml -f 30 -i "${inventoryPath}"`);
   }
 
   async clean() {

--- a/src/lib/cmd.js
+++ b/src/lib/cmd.js
@@ -3,9 +3,13 @@ const { spawn } = require('child_process');
 
 
 module.exports = {
-  exec: async (command, options={}) => {
+  splitCommandAndArgs: function (command) {
+    const regex = new RegExp('"[^"]+"|[\\S]+', 'g');
+    return command.match(regex).map(s => s.replace(/"/g, ''));
+  }, exec: async (command, options={}) => {
     return new Promise((resolve, reject) => {
-      const items = command.split(' ');
+      let items = module.exports.splitCommandAndArgs(command);
+
       const child = spawn(items[0], items.slice(1), options);
       if(options.detached) {
         child.unref();

--- a/test/lib/cmd.js
+++ b/test/lib/cmd.js
@@ -1,0 +1,26 @@
+const {splitCommandAndArgs} = require('../../src/lib/cmd');
+
+require('chai').should()
+
+describe('Command splitting', () => {
+
+  it('preserves args with spaces in but in quotes', () => {
+    splitCommandAndArgs(`ansible-playbook main.yml -f 30 -i "/Users/user/Library/Application Support/polkadot-secure-validator/build/w3f/ansible/inventory"`)
+      .should.deep.eq(
+      [
+        'ansible-playbook',
+        'main.yml',
+        '-f',
+        '30',
+        '-i',
+        '/Users/user/Library/Application Support/polkadot-secure-validator/build/w3f/ansible/inventory'
+      ]
+    );
+
+  });
+
+  it('preserves args ine key=value format', () => {
+    splitCommandAndArgs(`terraform init -var state_project=kusama-infrastructure-state`)
+      .should.deep.eq(['terraform', 'init', '-var', 'state_project=kusama-infrastructure-state'])
+  });
+});


### PR DESCRIPTION
On macOS the default data path is `~/Library/Application Support/`. Due to the space in the path `ansible-playbook` command failed, as the argument split was done by spaces.

This pull request changes splitting arguments so that args within `"` are preserved with spaces.