### PR TITLE
Option to set base path

### DIFF
--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -7,6 +7,7 @@ vpnpeer_address=10.0.0.1
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
+base_path='' # Use default db location
 
 [validator:children]
 validator-0
@@ -21,6 +22,7 @@ vpnpeer_address=10.0.0.2
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
+base_path='' # Use default db location
 
 [public-1]
 40.81.189.214
@@ -31,6 +33,7 @@ vpnpeer_address=10.0.0.3
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
+base_path='' # Use default db location
 
 [public-2]
 35.190.164.158
@@ -41,6 +44,7 @@ vpnpeer_address=10.0.0.4
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
+base_path='' # Use default db location
 
 [public:children]
 public-0

--- a/ansible/inventory.sample
+++ b/ansible/inventory.sample
@@ -7,7 +7,6 @@ vpnpeer_address=10.0.0.1
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
-base_path='' # Use default db location
 
 [validator:children]
 validator-0
@@ -22,7 +21,7 @@ vpnpeer_address=10.0.0.2
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
-base_path='' # Use default db location
+base_path='/mnt/volume01/polkadot/' # Custom location for chain
 
 [public-1]
 40.81.189.214
@@ -33,7 +32,6 @@ vpnpeer_address=10.0.0.3
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
-base_path='' # Use default db location
 
 [public-2]
 35.190.164.158
@@ -44,7 +42,6 @@ vpnpeer_address=10.0.0.4
 vpnpeer_cidr_suffix=24
 telemetryUrl=wss://mi.private.telemetry.backend/
 loggingFilter='sync=trace,afg=trace,babe=debug'
-base_path='' # Use default db location
 
 [public:children]
 public-0

--- a/ansible/roles/polkadot-common/tasks/main.yml
+++ b/ansible/roles/polkadot-common/tasks/main.yml
@@ -64,6 +64,7 @@
   systemd:
     name: polkadot.service
     state: started
+    daemon_reload: yes
   changed_when: false
   when: polkadot_service_running.stdout == "no"
 

--- a/ansible/roles/polkadot-common/tasks/main.yml
+++ b/ansible/roles/polkadot-common/tasks/main.yml
@@ -64,7 +64,6 @@
   systemd:
     name: polkadot.service
     state: started
-    daemon_reload: yes
   changed_when: false
   when: polkadot_service_running.stdout == "no"
 

--- a/ansible/roles/polkadot-public/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-public/templates/polkadot.service.j2
@@ -19,6 +19,9 @@ ExecStart=/usr/local/bin/polkadot \
          {% for reserved_node in groups['validator'] %}
          --sentry /ip4/{{ hostvars[reserved_node].vpnpeer_address }}/tcp/30333/p2p/{{ hostvars[reserved_node].p2p_peer_id }} \
          {% endfor %}
+         {% if hostvars[inventory_hostname].base_path is defined and hostvars[inventory_hostname].base_path|length %}
+         --base-path '{{ hostvars[inventory_hostname].base_path }}' \
+         {% endif %}
          {% if hostvars[inventory_hostname].telemetryUrl is defined and hostvars[inventory_hostname].telemetryUrl|length %}
          --telemetry-url '{{ hostvars[inventory_hostname].telemetryUrl }} 1'
          {% else %}

--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -27,6 +27,9 @@ ExecStart=/usr/local/bin/polkadot \
            {% endif %}
          {% endfor %}
          --chain={{ chain }} \
+         {% if hostvars[inventory_hostname].base_path is defined and hostvars[inventory_hostname].base_path|length %}
+         --base-path '{{ hostvars[inventory_hostname].base_path }}' \
+         {% endif %}
          {% if hostvars[inventory_hostname].telemetryUrl is defined and hostvars[inventory_hostname].telemetryUrl|length %}
          --telemetry-url '{{ hostvars[inventory_hostname].telemetryUrl }} 1'
          {% else %}


### PR DESCRIPTION
Option to set the base path for Polkadot (filesystem location of the blockchain).

Inventory example (`base_path`):

```ini
[public-0:vars]
ansible_user=ubuntu
vpnpeer_address=10.0.0.2
vpnpeer_cidr_suffix=24
telemetryUrl=wss://mi.private.telemetry.backend/
loggingFilter='sync=trace,afg=trace,babe=debug'
base_path='/mnt/volume01/polkadot/' # Custom location for chain
```