### PR TITLE
configurable-chain-polkadot-network-id

### DIFF
--- a/ansible/roles/polkadot-backup-keystore/tasks/main.yml
+++ b/ansible/roles/polkadot-backup-keystore/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: backup keystore
   copy:
-    src: /home/polkadot/.local/share/polkadot/chains/ksmcc3/keystore
+    src: "/home/polkadot/.local/share/polkadot/chains/{{ polkadot_network_id }}/keystore"
     dest: /home/polkadot/keystore
     remote_src: yes

--- a/ansible/roles/polkadot-common/defaults/main.yml
+++ b/ansible/roles/polkadot-common/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for polkadot
+chain: "kusama"

--- a/ansible/roles/polkadot-common/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-common/templates/polkadot.service.j2
@@ -6,7 +6,8 @@ User=polkadot
 Group=polkadot
 ExecStart=/usr/local/bin/polkadot \
          --name polkadot-dummy \
-         --validator
+         --validator \
+         --chain={{ chain }} 
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/polkadot-public/defaults/main.yml
+++ b/ansible/roles/polkadot-public/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for polkadot-public
-chain: kusama
+chain: "kusama"

--- a/ansible/roles/polkadot-restore-db/tasks/main.yml
+++ b/ansible/roles/polkadot-restore-db/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: download db
   get_url:
     url: "https://storage.googleapis.com/{{ chain }}-db/db.tar.gz"
-    dest: "/home/polkadot/.local/share/polkadot/{{ polkadot_network_id }}//"
+    dest: "/home/polkadot/.local/share/polkadot/chains/{{ polkadot_network_id }}//"
     mode: '0700'
     owner: 'polkadot'
     group: 'polkadot'

--- a/ansible/roles/polkadot-restore-db/tasks/main.yml
+++ b/ansible/roles/polkadot-restore-db/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: download db
   get_url:
-    url: https://storage.googleapis.com/kusama-db/db.tar.gz
-    dest: /home/polkadot/.local/share/polkadot/chains/ksmcc3/
+    url: "https://storage.googleapis.com/{{ chain }}-db/db.tar.gz"
+    dest: "/home/polkadot/.local/share/polkadot/{{ polkadot_network_id }}//"
     mode: '0700'
     owner: 'polkadot'
     group: 'polkadot'
@@ -14,7 +14,7 @@
 - name: unpack db
   shell: |
     set -o pipefail
-    cd /home/polkadot/.local/share/polkadot/chains/ksmcc3/
+    cd /home/polkadot/.local/share/polkadot/chains/{{ polkadot_network_id }}/
     mv db db.back
     tar xzf db.tar.gz
     rm db.tar.gz

--- a/ansible/roles/polkadot-validator-session-info/defaults/main.yml
+++ b/ansible/roles/polkadot-validator-session-info/defaults/main.yml
@@ -1,4 +1,4 @@
 subkey_binary_url: 'https://github.com/w3f/substrate/releases/download/e0f3fa/subkey'
 subkey_binary_checksum: 'sha256:f74a06442e76c3bb97d27a168b9710ef062ae5640ad82e7d42b8fb613f8be9d9'
-polkadot_network_id: 'ksmcc2'
+polkadot_network_id: "ksmcc2"
 build_dir: '/tmp'

--- a/ansible/roles/polkadot-validator/defaults/main.yml
+++ b/ansible/roles/polkadot-validator/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for polkadot-validator
-chain: kusama
+chain: "kusama"
+polkadot_network_id: "ksmcc3"

--- a/ansible/roles/polkadot-validator/molecule/default/molecule.yml
+++ b/ansible/roles/polkadot-validator/molecule/default/molecule.yml
@@ -23,11 +23,11 @@ provisioner:
     host_vars:
       polkadot-validator-validator-node:
         vpnpeer_address: 10.0.0.1
-        polkadot_network_id: ksma
+        polkadot_network_id: ksmcc3
       polkadot-validator-public-node:
         vpnpeer_address: 10.0.0.2
         p2p_peer_id: peerid
-        polkadot_network_id: ksma
+        polkadot_network_id: ksmcc3
 verifier:
   name: testinfra
   lint:

--- a/config/main.sample.json
+++ b/config/main.sample.json
@@ -11,6 +11,7 @@
       "checksum": "sha256:b2503fd932f85f4e5baf161268854bf5d22001869b84f00fd2d1f57b51b72424"
     }
   },
+  "chain": "kusama",
   "polkadotNetworkId": "ksmcc3",
   "state": {
     "project": "my_gcp_state_project"

--- a/config/main.template.json
+++ b/config/main.template.json
@@ -11,6 +11,7 @@
       "checksum": "sha256:b2503fd932f85f4e5baf161268854bf5d22001869b84f00fd2d1f57b51b72424"
     }
   },
+  "chain": "<chain>",
   "polkadotNetworkId": "<polkadot-network-id>",
   "state": {
     "project": "<gcp-state-project-id>"

--- a/src/lib/clients/ansible.js
+++ b/src/lib/clients/ansible.js
@@ -46,6 +46,7 @@ class Ansible {
 
       polkadotBinaryUrl: this.config.polkadotBinary.url,
       polkadotBinaryChecksum: this.config.polkadotBinary.checksum,
+      chain: this.config.chain || 'kusama',
       polkadotNetworkId: this.config.polkadotNetworkId || 'ksmcc2',
 
       validators,

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -40,6 +40,7 @@ project={{ project }}
 ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ConnectTimeout=25 -o ControlMaster=no -o UserKnownHostsFile=/dev/null'
 polkadot_binary_url='{{ polkadotBinaryUrl }}'
 polkadot_binary_checksum='{{ polkadotBinaryChecksum }}'
+chain='{{ chain }}'
 polkadot_network_id='{{ polkadotNetworkId }}'
 build_dir={{ buildDir }}
 node_exporter_enabled='{{ nodeExporterEnabled }}'


### PR DESCRIPTION
- backup keystore now uses polkadot-network-id
- added chain to Polkadot Dummy Node
- download db uses chain and polkadot-network-id
- moved from public-node and validator to polkadot-common defaults to "chain"
- added chain to main.sample.json
- added chain to main.template.json
- added chain to ansible client and defaults to kusama
- added chain to ansible_inventory tpl