### PR TITLE
replacing --reserved-nodes flag with --sentry-nodes for validators

### DIFF
--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -20,11 +20,11 @@ ExecStart=/usr/local/bin/polkadot \
          -l{{ hostvars[inventory_hostname].loggingFilter }} \
          {% endif %}
          {% for reserved_node in (groups['public'] | shuffle)[:10] %}
-         --reserved-nodes /ip4/{{ hostvars[reserved_node].vpnpeer_address }}/tcp/30333/p2p/{{ hostvars[reserved_node].p2p_peer_id }} \
+         --sentry-nodes /ip4/{{ hostvars[reserved_node].vpnpeer_address }}/tcp/30333/p2p/{{ hostvars[reserved_node].p2p_peer_id }} \
          {% endfor %}
          {% for reserved_node in (groups['validator'] | shuffle)[:5] %}
            {% if hostvars[inventory_hostname].vpnpeer_address != hostvars[reserved_node].vpnpeer_address %}
-         --reserved-nodes /ip4/{{ hostvars[reserved_node].vpnpeer_address }}/tcp/30333/p2p/{{ hostvars[reserved_node].p2p_peer_id }} \
+         --sentry-nodes /ip4/{{ hostvars[reserved_node].vpnpeer_address }}/tcp/30333/p2p/{{ hostvars[reserved_node].p2p_peer_id }} \
            {% endif %}
          {% endfor %}
          --chain={{ chain }} \


### PR DESCRIPTION
With the release of v0.8.5 `--sentry-nodes` will replace the `--reserved-nodes` flag in the future. Tested on the kusama network, works fine. 