### PR TITLE
Fixed aws ami

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-secure-validator",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "src/index.js",
   "repository": "https://github.com/w3f/polkadot-secure-validator",
   "author": "W3F Infrastructure Team <devops@web3.foundation>",

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -3,22 +3,6 @@ resource "aws_key_pair" "key-{{ name }}" {
   public_key = var.public_key
 }
 
-data "aws_ami" "ubuntu" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-${var.image}-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"] # Canonical
-}
-
 resource "aws_vpc" "main-{{ name }}" {
   cidr_block = "172.26.0.0/16"
 
@@ -123,7 +107,7 @@ resource "aws_security_group_rule" "allow_all-{{ name }}" {
 }
 
 resource "aws_instance" "main-{{ name }}" {
-  ami           = "${data.aws_ami.ubuntu.id}"
+  ami           = var.image
   instance_type = var.machine_type
   key_name      = var.name
   count         = var.node_count

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -35,5 +35,5 @@ variable "name" {
 }
 
 variable "image" {
-  default = "bionic-18.04"
+  default = "ami-0e6273fe5a9a1ad93"
 }


### PR DESCRIPTION
Closes https://github.com/w3f/infrastructure/issues/273

This will prevent eventual machine recreations because of changes in the default provider ami's for specific operating system versions.