### PR TITLE
Improve security of polkadot.service

### DIFF
--- a/ansible/roles/polkadot-validator/templates/polkadot.service.j2
+++ b/ansible/roles/polkadot-validator/templates/polkadot.service.j2
@@ -30,6 +30,27 @@ ExecStart=/usr/local/bin/polkadot \
   {% endif %}
 
 Restart=always
+CapabilityBoundingSet=
+LockPersonality=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateMounts=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+RemoveIPC=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@clock @module @mount @reboot @swap @privileged
+UMask=0027
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This additional config is based on the output of `systemd-analyze security polkadot.service`. We recently added [our own](https://github.com/paritytech/polkadot/blob/master/scripts/packaging/polkadot.service) polkadot.service file in the polkadot repo and spent a little time researching which sandboxing and namespacing options we could take advantage of. Discussion for that PR is [here](https://github.com/paritytech/polkadot/pull/1676#discussion_r484540568).