### PR TITLE
Add inventory path for setup.sh to docs

### DIFF
--- a/GUIDE_ANSIBLE.md
+++ b/GUIDE_ANSIBLE.md
@@ -36,9 +36,10 @@ access keys to the SSH agent.
 
 All required data is saved in a [Ansible
 inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html),
-which by default is placed under `/etc/ansible/hosts` and must only be configured once.
-Most values from the [SAMPLE FILE](ansible/inventory.sample) can be copied. Only
-a handful of entries must be adjusted.
+which by default is placed under `/etc/ansible/hosts` (but you can create it
+anywhere you want) and must only be configured once. Most values from the
+[SAMPLE FILE](ansible/inventory.sample) can be copied. Only a handful of entries
+must be adjusted.
 
 For each node, the following information must be configured in the Ansible
 inventory:
@@ -50,8 +51,6 @@ inventory:
 * (optional) The logging filter.
 
 The other default values from the sample inventory can be left as is.
-
-**NOTE**: This guide assumes that the inventory is placed locally in `ansible/inventory.yml`.
 
 **NOTE**: Telemetry information exposes IP address, among other information. For
 this reason it's highly encouraged to use a [private telemetry
@@ -172,12 +171,12 @@ user@pc:~$ cd polkadot-secure-validator/ansible
 Once the inventory file is configured, simply run the setup script and specify
 the `sudo` password for the remote machines.
 
-**NOTE**: This script assumes that the inventory file is configured in
-`ansible/inventory.yml`.
+**NOTE**: If no inventory path is specified, it will try to look for
+`ansible/inventory.yml` by default.
 
 ```console
 user@pc:~/polkadot-secure-validator/ansible$ chmod +x setup.sh
-user@pc:~/polkadot-secure-validator/ansible$ ./setup.sh
+user@pc:~/polkadot-secure-validator/ansible$ ./setup.sh my_inventory.yml
 Sudo password for remote servers:
 >> Pulling upstream changes... [OK]
 >> Testing Ansible availability... [OK]
@@ -195,7 +194,7 @@ Alternatively, execute the Playbook manually ("become" implies `sudo`
 privileges).
 
 ```console
-user@pc:~/polkadot-secure-validator/ansible$ ansible-playbook -i inventory.yml main.yml --become --ask-become
+user@pc:~/polkadot-secure-validator/ansible$ ansible-playbook -i my_inventory.yml main.yml --become --ask-become
 ```
 
 The `setup.sh` script handles some extra functionality, such as downloading the


### PR DESCRIPTION
This documents a recent PR which allows you to specify a path of the inventory to the `setup.sh` script.

```bash
user@pc:~/polkadot-secure-validator/ansible$ ./setup.sh my_inventory.yml
Sudo password for remote servers:
>> Pulling upstream changes... [OK]
>> Testing Ansible availability... [OK]
>> Finding validator hosts... [OK]
  hosts (2):
    147.75.76.65
    162.12.35.55
>> Testing connectivity to hosts... [OK]
>> Executing Ansible Playbook...

...

```